### PR TITLE
1.3.5: Bug Fixes and API Removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ compileJava {
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 }
-version = "1.3.4"
+version = "1.3.5"
 group = "dev.meyi.bn"
 archivesBaseName = "BazaarNotifier"
 

--- a/discord-bot/src/bazaar/bazaar_conversions.json
+++ b/discord-bot/src/bazaar/bazaar_conversions.json
@@ -225,5 +225,18 @@
   "ENCHANTED_ANCIENT_CLAW": "Enchanted Ancient Claw",
   "REFINED_MINERAL": "Refined Mineral",
   "SHARK_BAIT": "Shark Bait",
-  "HYPER_CATALYST": "Hyper Catalyst"
+  "HYPER_CATALYST": "Hyper Catalyst",
+  "ECTOPLASM": "Ectoplasm",
+  "PUMPKIN_GUTS": "Pumpkin Guts",
+  "SPOOKY_SHARD": "Spooky Shard",
+  "WEREWOLF_SKIN": "Werewolf Skin",
+  "SOUL_FRAGMENT": "Soul Fragment",
+  "JACOBS_TICKET": "Jacob's Ticket",
+  "EXP_BOTTLE": "Experience Bottle",
+  "GRAND_EXP_BOTTLE": "Grand Experience Bottle",
+  "TITANIC_EXP_BOTTLE": "Titanic Experience Bottle",
+  "COLOSSAL_EXP_BOTTLE": "Colossal Experience Bottle",
+  "POLISHED_PUMPKIN": "Polished Pumpkin",
+  "TIGHTLY_TIED_HAY_BALE": "Tightly-Tied Hale Bale",
+  "MUTANT_NETHER_STALK": "Mutant Nether Wart"
 }

--- a/src/main/java/dev/meyi/bn/BazaarNotifier.java
+++ b/src/main/java/dev/meyi/bn/BazaarNotifier.java
@@ -28,7 +28,7 @@ import org.json.JSONTokener;
 public class BazaarNotifier {
 
   public static final String MODID = "BazaarNotifier";
-  public static final String VERSION = "1.3.4";
+  public static final String VERSION = "1.3.5";
   public static final String prefix =
       EnumChatFormatting.GOLD + "[BazaarNotifier] " + EnumChatFormatting.RESET;
   public static String apiKey = "";
@@ -40,6 +40,7 @@ public class BazaarNotifier {
   public static boolean inBazaar = false;
   public static boolean forceRender = false;
   public static boolean validApiKey = false;
+  public static boolean apiKeyDisabled = true; // Change this if an api key is ever required to access the bazaar again.
 
   public static JSONArray orders = new JSONArray();
   public static JSONObject bazaarDataRaw = new JSONObject();
@@ -57,7 +58,7 @@ public class BazaarNotifier {
 
   public static void resetMod() {
     modules.resetAll();
-    orders = Defaults.DEFAULT_ORDERS_LAYOUT;
+    orders = Defaults.DEFAULT_ORDERS_LAYOUT();
   }
 
   @Mod.EventHandler

--- a/src/main/java/dev/meyi/bn/commands/BazaarNotifierCommand.java
+++ b/src/main/java/dev/meyi/bn/commands/BazaarNotifierCommand.java
@@ -1,6 +1,7 @@
 package dev.meyi.bn.commands;
 
 import dev.meyi.bn.BazaarNotifier;
+import dev.meyi.bn.utilities.Defaults;
 import dev.meyi.bn.utilities.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ public class BazaarNotifierCommand extends CommandBase {
     if (ics instanceof EntityPlayer) {
       EntityPlayer player = (EntityPlayer) ics;
       if (args.length == 1 && args[0].equalsIgnoreCase("toggle")) {
-        if (!BazaarNotifier.apiKey.equals("")) {
+        if (!BazaarNotifier.apiKey.equals("") || BazaarNotifier.apiKeyDisabled) {
           BazaarNotifier.orders = new JSONArray();
           BazaarNotifier.activeBazaar ^= true;
           player.addChatMessage(new ChatComponentText(
@@ -59,6 +60,7 @@ public class BazaarNotifierCommand extends CommandBase {
               player.addChatMessage(new ChatComponentText(
                   BazaarNotifier.prefix + EnumChatFormatting.RED
                       + "Your api key has been set."));
+              BazaarNotifier.apiKey = "";
               BazaarNotifier.validApiKey = true;
               BazaarNotifier.activeBazaar = true;
             } else {
@@ -84,10 +86,16 @@ public class BazaarNotifierCommand extends CommandBase {
         System.out.println(BazaarNotifier.orders);
         player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + EnumChatFormatting.RED
             + "Orders dumped to the log file"));
-      } else if (args.length == 1 && args[0].equalsIgnoreCase("reset")) {
-        BazaarNotifier.resetMod();
-        player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + EnumChatFormatting.RED
-            + "All module locations have been reset and the order list has been emptied"));
+      } else if (args.length >= 1 && args[0].equalsIgnoreCase("reset")) {
+        if (args.length == 1) {
+          BazaarNotifier.resetMod();
+          player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + EnumChatFormatting.RED
+              + "All module locations have been reset and the order list has been emptied"));
+        } else if (args.length == 2 && args[1].equalsIgnoreCase("orders")){
+          BazaarNotifier.orders = Defaults.DEFAULT_ORDERS_LAYOUT();
+          player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + EnumChatFormatting.RED
+              + "Your orders have been cleared"));
+        }
       } else if (args.length >= 1 && args[0].equalsIgnoreCase("find")) {
         if (args.length == 1) {
           player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + EnumChatFormatting.RED
@@ -125,7 +133,7 @@ public class BazaarNotifierCommand extends CommandBase {
             + "The command you just tried to do doesn't exist. Do /bn"));
       } else {
         player.addChatMessage(new ChatComponentText(BazaarNotifier.prefix + "\n" +
-            EnumChatFormatting.RED + "/bn dump\n" + EnumChatFormatting.RED + "/bn reset\n"
+            EnumChatFormatting.RED + "/bn dump\n" + EnumChatFormatting.RED + "/bn reset orders\n"
             + EnumChatFormatting.RED + "/bn api (key)\n\n" + EnumChatFormatting.RED + "/bn toggle\n"
             + EnumChatFormatting.RED + "/bn find (item)\n"
             + BazaarNotifier.prefix

--- a/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
+++ b/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
@@ -16,9 +16,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import org.json.JSONObject;
-import org.lwjgl.Sys;
-import scala.Console;
-import scala.collection.immutable.Stream;
 
 public class ChestTickHandler {
 
@@ -31,24 +28,23 @@ public class ChestTickHandler {
       if (Minecraft.getMinecraft().currentScreen instanceof GuiChest && BazaarNotifier.inBazaar) {
 
         IInventory chest = ((GuiChest) Minecraft.getMinecraft().currentScreen).lowerChestInventory;
-        String chestName = Utils.stripString(chest.getDisplayName().getUnformattedText().toLowerCase());
+        String chestName = Utils
+            .stripString(chest.getDisplayName().getUnformattedText().toLowerCase());
 
         if (chest.hasCustomName() && !lastScreenDisplayName.equalsIgnoreCase(chestName)) {
-
           if (chestName.equals("confirm buy order") ||
-                  chestName.equals("confirm sell offer")) {
+              chestName.equals("confirm sell offer")) {
 
-            if(chest.getStackInSlot(13) == null){
+            if (chest.getStackInSlot(13) == null) {
               return;
             }
+            lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
             orderConfirmation(chest);
 
-          }else if(chestName.contains("bazaar orders")){
+          } else if (chestName.contains("bazaar orders")) {
+            lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
             updateBazaarOrders(chest);
           }
-
-          lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
-
         }
       }
     }
@@ -58,6 +54,7 @@ public class ChestTickHandler {
     for (int i = 0; i < chest.getSizeInventory(); i++) {
       if (chest.getStackInSlot(i) != null
           && Item.itemRegistry.getIDForObject(chest.getStackInSlot(i).getItem()) != 160    // Glass
+          && Item.itemRegistry.getIDForObject(chest.getStackInSlot(i).getItem()) != 102    // Glass
           && Item.itemRegistry.getIDForObject(chest.getStackInSlot(i).getItem()) != 262) { // Arrow
         NBTTagList lorePreFilter = chest.getStackInSlot(i).getTagCompound()
             .getCompoundTag("display")
@@ -147,7 +144,6 @@ public class ChestTickHandler {
       double price = Double.parseDouble(StringUtils.stripControlCodes(
           chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")
               .getTagList("Lore", 8).getStringTagAt(2)).split(" ")[3].replaceAll(",", ""));
-
 
       String product = StringUtils.stripControlCodes(
           chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")

--- a/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
+++ b/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
@@ -35,15 +35,17 @@ public class ChestTickHandler {
           if (chestName.equals("confirm buy order") ||
               chestName.equals("confirm sell offer")) {
 
-            if (chest.getStackInSlot(13) == null) {
-              return;
+            if (chest.getStackInSlot(13) != null) {
+              lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
+              orderConfirmation(chest);
             }
-            lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
-            orderConfirmation(chest);
 
           } else if (chestName.contains("bazaar orders")) {
-            lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
-            updateBazaarOrders(chest);
+            if (chest.getStackInSlot(chest.getSizeInventory()-5) != null
+                && Item.itemRegistry.getIDForObject(chest.getStackInSlot(chest.getSizeInventory()-5).getItem()) == 262) {
+              lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
+              updateBazaarOrders(chest);
+            }
           }
         }
       }

--- a/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
+++ b/src/main/java/dev/meyi/bn/handlers/ChestTickHandler.java
@@ -16,6 +16,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import org.json.JSONObject;
+import org.lwjgl.Sys;
+import scala.Console;
+import scala.collection.immutable.Stream;
 
 public class ChestTickHandler {
 
@@ -26,18 +29,26 @@ public class ChestTickHandler {
   public void onChestTick(TickEvent e) {
     if (e.phase == Phase.END) {
       if (Minecraft.getMinecraft().currentScreen instanceof GuiChest && BazaarNotifier.inBazaar) {
+
         IInventory chest = ((GuiChest) Minecraft.getMinecraft().currentScreen).lowerChestInventory;
-        if (chest.hasCustomName() && !lastScreenDisplayName
-            .equalsIgnoreCase(Utils.stripString(chest.getDisplayName().getUnformattedText()))) {
-          lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
-          String chestName = Utils.stripString(chest.getDisplayName().getUnformattedText())
-              .toLowerCase();
-          if (chestName.contains("bazaar orders")) {
-            updateBazaarOrders(chest);
-          } else if (chestName.equals("confirm buy order") || chestName
-              .equals("confirm sell offer")) {
+        String chestName = Utils.stripString(chest.getDisplayName().getUnformattedText().toLowerCase());
+
+        if (chest.hasCustomName() && !lastScreenDisplayName.equalsIgnoreCase(chestName)) {
+
+          if (chestName.equals("confirm buy order") ||
+                  chestName.equals("confirm sell offer")) {
+
+            if(chest.getStackInSlot(13) == null){
+              return;
+            }
             orderConfirmation(chest);
+
+          }else if(chestName.contains("bazaar orders")){
+            updateBazaarOrders(chest);
           }
+
+          lastScreenDisplayName = Utils.stripString(chest.getDisplayName().getUnformattedText());
+
         }
       }
     }
@@ -130,28 +141,36 @@ public class ChestTickHandler {
   }
 
   private void orderConfirmation(IInventory chest) {
+
     if (chest.getStackInSlot(13) != null) {
+
       double price = Double.parseDouble(StringUtils.stripControlCodes(
           chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")
               .getTagList("Lore", 8).getStringTagAt(2)).split(" ")[3].replaceAll(",", ""));
+
+
       String product = StringUtils.stripControlCodes(
           chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")
               .getTagList("Lore", 8).getStringTagAt(4)).split("x ")[1];
+
       if (!BazaarNotifier.bazaarConversionsReversed
           .has(product)) {
         Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
             BazaarNotifier.prefix + EnumChatFormatting.RED
                 + "The bazaar item you just put an order for doesn't exist. Please report this in the discord server"));
+
       } else {
         String productName = BazaarNotifier.bazaarConversionsReversed
             .getString(product);
         String productWithAmount = StringUtils.stripControlCodes(
             chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")
                 .getTagList("Lore", 8).getStringTagAt(4)).split(": ")[1];
+
         int amount = Integer.parseInt(StringUtils.stripControlCodes(
             chest.getStackInSlot(13).getTagCompound().getCompoundTag("display")
                 .getTagList("Lore", 8).getStringTagAt(4)).split(": ")[1].split("x ")[0]
             .replaceAll(",", ""));
+
         EventHandler.productVerify[0] = productName;
         EventHandler.productVerify[1] = productWithAmount;
         EventHandler.verify = new JSONObject()

--- a/src/main/java/dev/meyi/bn/handlers/EventHandler.java
+++ b/src/main/java/dev/meyi/bn/handlers/EventHandler.java
@@ -105,7 +105,7 @@ public class EventHandler {
 
   @SubscribeEvent
   public void menuOpenedEvent(GuiOpenEvent e) {
-    if (e.gui instanceof GuiChest && BazaarNotifier.validApiKey
+    if (e.gui instanceof GuiChest && (BazaarNotifier.validApiKey || BazaarNotifier.apiKeyDisabled)
         && ((((GuiChest) e.gui).lowerChestInventory.hasCustomName() && (Utils
         .stripString(((GuiChest) e.gui).lowerChestInventory.getDisplayName().getUnformattedText())
         .startsWith("Bazaar") || Utils

--- a/src/main/java/dev/meyi/bn/handlers/UpdateHandler.java
+++ b/src/main/java/dev/meyi/bn/handlers/UpdateHandler.java
@@ -62,7 +62,7 @@ public class UpdateHandler {
             }
           }
           BazaarNotifier.validApiKey = Utils.validateApiKey();
-          if (!BazaarNotifier.validApiKey) {
+          if (!BazaarNotifier.validApiKey && !BazaarNotifier.apiKeyDisabled) {
             Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
                 BazaarNotifier.prefix + EnumChatFormatting.RED
                     + "The mod doesn't have access to a valid api key yet. Please run /bn api (key) to set your key"));

--- a/src/main/java/dev/meyi/bn/utilities/Defaults.java
+++ b/src/main/java/dev/meyi/bn/utilities/Defaults.java
@@ -10,5 +10,7 @@ public class Defaults {
   public static final int BANK_MODULE_Y = 10;
   public static final int NOTIFICATION_MODULE_X = 5;
   public static final int NOTIFICATION_MODULE_Y = 10;
-  public static final JSONArray DEFAULT_ORDERS_LAYOUT = new JSONArray();
+  public static JSONArray DEFAULT_ORDERS_LAYOUT() {
+    return new JSONArray();
+  }
 }

--- a/src/main/java/dev/meyi/bn/utilities/ScheduledEvents.java
+++ b/src/main/java/dev/meyi/bn/utilities/ScheduledEvents.java
@@ -33,7 +33,7 @@ public class ScheduledEvents {
       if (!inOutdatedRequest) {
         inOutdatedRequest = true;
         try {
-          if (BazaarNotifier.activeBazaar && BazaarNotifier.validApiKey) {
+          if (BazaarNotifier.activeBazaar && (BazaarNotifier.validApiKey || BazaarNotifier.apiKeyDisabled)) {
             BazaarNotifier.bazaarDataRaw = Utils.getBazaarData();
             if (BazaarNotifier.orders.length() > 0) {
               for (int i = 0; i < BazaarNotifier.orders.length(); i++) {

--- a/src/main/java/dev/meyi/bn/utilities/Suggester.java
+++ b/src/main/java/dev/meyi/bn/utilities/Suggester.java
@@ -9,7 +9,7 @@ public class Suggester {
 
   public static void basic() {
     try {
-      if (BazaarNotifier.validApiKey) {
+      if (BazaarNotifier.validApiKey || BazaarNotifier.apiKeyDisabled) {
         JSONObject bazaarData = BazaarNotifier.bazaarDataRaw;
         Iterator<String> bazaarKeys = bazaarData.keys();
         JSONArray bazaarDataFormatted = new JSONArray();

--- a/src/main/java/dev/meyi/bn/utilities/Utils.java
+++ b/src/main/java/dev/meyi/bn/utilities/Utils.java
@@ -32,8 +32,12 @@ public class Utils {
 
   public static JSONObject getBazaarData() throws IOException {
     HttpClient client = HttpClientBuilder.create().build();
+    String apiBit = "";
+    if (!BazaarNotifier.apiKeyDisabled) {
+      apiBit = "?key=" + BazaarNotifier.apiKey;
+    }
     HttpGet request = new HttpGet(
-        "https://api.hypixel.net/skyblock/bazaar?key=" + BazaarNotifier.apiKey);
+        "https://api.hypixel.net/skyblock/bazaar" + apiBit);
     HttpResponse response = client.execute(request);
 
     String result = IOUtils.toString(new BufferedReader

--- a/src/main/resources/bazaarConversions.json
+++ b/src/main/resources/bazaarConversions.json
@@ -231,5 +231,12 @@
   "SPOOKY_SHARD": "Spooky Shard",
   "WEREWOLF_SKIN": "Werewolf Skin",
   "SOUL_FRAGMENT": "Soul Fragment",
-  "JACOBS_TICKET": "Jacob's Ticket"
+  "JACOBS_TICKET": "Jacob's Ticket",
+  "EXP_BOTTLE": "Experience Bottle",
+  "GRAND_EXP_BOTTLE": "Grand Experience Bottle",
+  "TITANIC_EXP_BOTTLE": "Titanic Experience Bottle",
+  "COLOSSAL_EXP_BOTTLE": "Colossal Experience Bottle",
+  "POLISHED_PUMPKIN": "Polished Pumpkin",
+  "TIGHTLY_TIED_HAY_BALE": "Tightly-Tied Hale Bale",
+  "MUTANT_NETHER_STALK": "Mutant Nether Wart"
 }

--- a/src/main/resources/bazaarConversionsReversed.json
+++ b/src/main/resources/bazaarConversionsReversed.json
@@ -230,5 +230,12 @@
   "Spooky Shard": "SPOOKY_SHARD",
   "Werewolf Skin": "WEREWOLF_SKIN",
   "Soul Fragment": "SOUL_FRAGMENT",
-  "Jacob's Ticket": "JACOBS_TICKET"
+  "Jacob's Ticket": "JACOBS_TICKET",
+  "Experience Bottle": "EXP_BOTTLE",
+  "Grand Experience Bottle": "GRAND_EXP_BOTTLE",
+  "Titanic Experience Bottle": "TITANIC_EXP_BOTTLE",
+  "Colossal Experience Bottle": "COLOSSAL_EXP_BOTTLE",
+  "Polished Pumpkin": "POLISHED_PUMPKIN",
+  "Tightly-Tied Hale Bale": "TIGHTLY_TIED_HAY_BALE",
+  "Mutant Nether Wart": "MUTANT_NETHER_STALK"
 }


### PR DESCRIPTION
1. The api key requirement has been disabled for the time being since Hypixel has continued to not require it for the /skyblock/bazaar endpoint. New users won't need to input an api key to use the mod.
2. Orders should always be added unless there isn't a proper conversion in the mod. See #26 
- If this doesn't quite do the trick, I have some more ideas.
3. Added `/bn reset orders` to only reset the orders and fixed the reset command to actually clear the orders list.